### PR TITLE
Fixed fetchPageNumbers in DevtoArticlesPaginated to return a valid array

### DIFF
--- a/src/components/DevtoArticlesPaginated.jsx
+++ b/src/components/DevtoArticlesPaginated.jsx
@@ -50,7 +50,7 @@ class DevtoArticlesPaginated extends React.Component {
   fetchPageNumbers = () => {
     const { totalPages, maxPages } = this.state
 
-    if (totalPages <= 1) return null
+    if (totalPages <= 0) return []
 
     const lastPage = Math.max(1, Math.min(maxPages, totalPages))
     return range(1, lastPage)


### PR DESCRIPTION
The component was expecting an array for showing the list of available
pages but when there is just one the function returned a null value and
the component can not found the map function